### PR TITLE
feat: Add publishing mechanism

### DIFF
--- a/.github/workflows/zip-repository.yml
+++ b/.github/workflows/zip-repository.yml
@@ -1,0 +1,26 @@
+name: Publish repository as Zip
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create zip of repository
+        run: |
+          zip -r openeo-${{ github.event.release.tag_name }}.zip . -x '*.git*' '.github*'
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: openeo-${{ github.event.release.tag_name }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+TBD
+
+# Publishing a New Release
+
+To trigger a build that creates and attaches a zip file of the repository to a GitHub Release, follow these steps:
+
+1. Ensure all your changes are committed and pushed to the main branch (or the branch you want to release).
+2. Go to the [Releases](https://github.com/minceheid/openeo/releases) page of this repository.
+3. Click on "Draft a new release".
+4. Fill in the tag version (e.g., `v1.2.3`), release title, and description as needed.
+5. Click "Publish release".
+
+Once the release is published, the GitHub Actions workflow will automatically:
+- Create a zip file of the repository contents (excluding git related folders)
+- Attach the zip file to the release
+
+No manual upload is required. The process is fully automated.
+
+If you encounter any issues, please check the Actions tab for workflow logs or contact a repository maintainer.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,19 @@ This software can be installed onto a Raspberry OS Lite install. We recommend th
 7. Close the EO enclosure, and apply power to it. The RPi Zero should boot, and if you got the configuration correct in step #3 above, it will then join your wireless network and you can log in with SSH (you should be able to find the RPi IP address from your broadband router). Note that the first time that you power up with a fresh SD card, it will take 10-15 minutes to fully boot before it is seen on the network.
 8. Log onto your account on the RPi Zero via SSH over the WiFi network, and run the following three commands. This will download a deployment script from github, run it to install the software onto your RPi, then reboots your RPi to allow the software to finish configuring and start up.
 
+To download the latest
+
 ~~~~
 wget https://raw.githubusercontent.com/minceheid/openeo/refs/heads/main/deploy.bash
 bash deploy.bash
+sudo reboot
+~~~~
+
+To download a specific version
+
+~~~~
+wget https://raw.githubusercontent.com/minceheid/openeo/refs/heads/main/deploy.bash
+bash deploy.bash v0.4
 sudo reboot
 ~~~~
 

--- a/boot.bash
+++ b/boot.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
-cd ~/openeo
+SCRIPT_DIR="$(dirname "$0")"
+cd $SCRIPT_DIR
 
 #####################
 echo "Wait for network connectivity (checks for default route)"

--- a/deploy.bash
+++ b/deploy.bash
@@ -1,15 +1,25 @@
 #!/usr/bin/bash
+# Usage: ./deploy.bash [version]
+# If a version is supplied, download the corresponding release from minceheid/openeo
+# Otherwise, download the main branch from minceheid/openeo
 
-# Get and extract main archive
-BRANCH=main
+if [ -n "$1" ]; then
+    VERSION="$1"
+    ZIP_URL="https://github.com/minceheid/openeo/releases/download/${VERSION}/openeo-${VERSION}.zip"
+    ZIP_FILE="openeo-${VERSION}.zip"
+    wget "$ZIP_URL" -O "$ZIP_FILE"
+    unzip "$ZIP_FILE" -d "openeo-${VERSION}"
+    # The crontab will allow openeo to start automatically at boot
+    echo "@reboot openeo-${VERSION}/boot.bash" >/tmp/crontab 
+else
+    BRANCH=main
+    wget https://github.com/minceheid/openeo/archive/refs/heads/$BRANCH.zip -O main.zip
+    unzip main.zip
+    mv openeo-$BRANCH openeo
+    # The crontab will allow openeo to start automatically at boot
+    echo "@reboot openeo/boot.bash" >/tmp/crontab 
+fi
 
-wget https://github.com/minceheid/openeo/archive/refs/heads/$BRANCH.zip
-unzip main.zip
-# The zip file includes the branch name, so remove that for a consistent pathname
-mv openeo-$BRANCH openeo
-
-# The crontab will allow openeo to start automatically at boot
-echo "@reboot openeo/boot.bash" >/tmp/crontab 
 crontab /tmp/crontab
 
 # Install prereq packages
@@ -18,3 +28,5 @@ sudo apt-get install -y python3-serial python3-websockets python3-jsonschema pyt
 # Update the SPI config
 sudo cp /boot/firmware/config.txt /tmp/config.txt
 sudo sh -c 'sed "s/#dtparam=spi=on/dtparam=spi=on/" </tmp/config.txt >/boot/firmware/config.txt'
+
+echo If you hava previous config.json, please copy it to the new openeo directory.


### PR DESCRIPTION
1. Add a workflow that attaches a repository zip to a Github release
2. Update the deploy script to allow an optional parameter that locks the deployment to a given release
3. Update the startup script to support openeo running from different folders (e.g. openeo-v0.2)
