### PR TITLE
fix: make charging more permissive

### DIFF
--- a/openeo.py
+++ b/openeo.py
@@ -185,10 +185,9 @@ def main():
 
             # If we are ready to charge (that is, there is a cable/car connected), and there is demand from the 
             # modules, then raise the Amp limit to the maximum requested by the modules
-            if (globalState.stateDict["eo_charger_state"] == "charge-unknown-state" or 
-                globalState.stateDict["eo_charger_state"] == "charging" or 
-                globalState.stateDict["eo_charger_state"] == "car-connected" or 
-                globalState.stateDict["eo_charger_state"] == "plug-present") and (globalState.stateDict["eo_amps_requested"] > 0):
+            # Note - we have had some unusual states reported here, preventing charging, so we are now checking
+            # for state_id >= 5 to eliminate suspected error states, but to otherwise be permissive.
+            if (globalState.stateDict["eo_charger_state_id"] >= 5) and (globalState.stateDict["eo_amps_requested"] > 0):
                 globalState.stateDict["eo_amps_limit"]=globalState.stateDict["eo_amps_requested"]
             else:
                 globalState.stateDict["eo_amps_limit"]=0


### PR DESCRIPTION
Some cars (e.g. MG5LR) appear to cause the charger to enter an unusal state (charging-complete) when resuming from a previously paused state. Fix is to be a bit more permissive of the charger state when allowing the charger to be set to a non-zero charging rate.