### PR TITLE
feat: Improved handling of serial overruns

### DIFF
--- a/globalState.py
+++ b/globalState.py
@@ -47,6 +47,9 @@ stateDict={
 
     # Always set charger to requested current, even if no car is connected
     "eo_always_supply_current": False,
+
+    # Counter of the number of serial overruns
+    "eo_serial_errors": 0,
     
     # Application (openeo) version
     "app_version" : appVer

--- a/openeo.py
+++ b/openeo.py
@@ -167,6 +167,8 @@ def main():
 
         # decode the charger status
         if result != None:
+            # Perhaps stupidly, we've already stripped off the prefix, which puts the positions
+            # for slicing the result string out by one, so let's put that prefix back on..
             result="!"+result
             try:
                 # TGO: this divisor results in an error of 9V at 230V on my unit, may need tweaking
@@ -192,7 +194,7 @@ def main():
             _LOGGER.debug("Amps Limit: "+str(globalState.stateDict["eo_amps_limit"])+"A")
             
         else:
-            _LOGGER.debug("Invalid result")
+            _LOGGER.debug("Ignoring State Update, we probably had a serial overrun")
 
         # Measure Pi CPU temperature. This is returned via OCPP and might be exposed in other interfaces later.
         # I'm not sure how useful this is, but presumably on a hot day under high CPU load whilst charging, 

--- a/openeoCharger.py
+++ b/openeoCharger.py
@@ -76,7 +76,7 @@ class openeoChargerClass:
         self.rs485.tx(packet)
         response = self.rs485.rx(recv_delay=3)
         if not response:
-            _LOGGER.info("Response from serial was empty")
+            _LOGGER.info("Response from serial was empty - possible serial overrun")
             return None
         try:
             response = response.decode("ascii")


### PR DESCRIPTION
Implements a counter in globalState to count the number of serial overrun errors that we encounter. This can be used to draw out metrics with Home Assistance or Prometheus. Also tidied up handling so that if the spi rx method detects a serial overrun, then it should return None to the caller to be clear that the read can't be trusted.