### PR TITLE
feat: add MQTT LWT and availability topic for Home Assistant

### DIFF
--- a/lib/homeassistant.py
+++ b/lib/homeassistant.py
@@ -82,7 +82,14 @@ class homeassistantClassPlugin(PluginSuperClass):
             self.mqtt_client.on_connect = self._on_connect
             self.mqtt_client.on_disconnect = self._on_disconnect
             self.mqtt_client.on_message = self._on_message
-            
+
+            self.mqtt_client.will_set(
+                self._get_availability_topic(),
+                payload="offline",
+                qos=1,
+                retain=True,
+            )
+
             # Connect to broker
             host = self.get_config("mqtt_host")
             port = self.get_config("mqtt_port")
@@ -99,6 +106,12 @@ class homeassistantClassPlugin(PluginSuperClass):
         if rc == 0:
             self.connected = True
             _LOGGER.info("Connected to MQTT broker")
+            self.mqtt_client.publish(
+                self._get_availability_topic(),
+                payload="online",
+                qos=1,
+                retain=True,
+            )
             # Subscribe to command topics
             self._subscribe_to_commands()
             # Send discovery messages after connection
@@ -325,6 +338,10 @@ class homeassistantClassPlugin(PluginSuperClass):
         }
         return defaults.get(field, "")
     
+    def _get_availability_topic(self):
+        device_id = self.get_config("device_id")
+        return f"openeo/{device_id}/availability"
+
     def _get_device_info(self):
         """Generate device information for Home Assistant"""
         return {
@@ -343,6 +360,7 @@ class homeassistantClassPlugin(PluginSuperClass):
         device_info = self._get_device_info()
         discovery_prefix = self.get_config("mqtt_discovery_prefix")
         device_id = self.get_config("device_id")
+        availability_topic = self._get_availability_topic()
         
         # Define all sensors to create in Home Assistant
         sensors = [
@@ -593,7 +611,9 @@ class homeassistantClassPlugin(PluginSuperClass):
                          "icon", "payload_on", "payload_off", "command_topic", "min", "max", "step", "options"]:
                 if field in entity:
                     config[field] = entity[field]
-            
+
+            config["availability"] = [{"topic": availability_topic}]
+
             topic = f"{discovery_prefix}/{entity['component']}/{device_id}/{entity['object_id']}/config"
             payload = json.dumps(config)
             
@@ -696,5 +716,14 @@ class homeassistantClassPlugin(PluginSuperClass):
     def __del__(self):
         """Cleanup MQTT connection on plugin destruction"""
         if self.mqtt_client and self.connected:
+            try:
+                self.mqtt_client.publish(
+                    self._get_availability_topic(),
+                    payload="offline",
+                    qos=1,
+                    retain=True,
+                )
+            except Exception:
+                pass
             self.mqtt_client.loop_stop()
             self.mqtt_client.disconnect()


### PR DESCRIPTION
## Problem

openeo had no MQTT Last Will and Testament (LWT) configured. When the charger went offline unexpectedly (power failure, crash), the MQTT broker had no message to publish on behalf of the client, so Home Assistant entities continued to show stale sensor values with no indication the device was unreachable.

## Changes

All changes are in `lib/homeassistant.py`.

- **`will_set()` before connect** — registers an LWT with the broker so it automatically publishes `offline` (retained, QoS 1) to `openeo/<device_id>/availability` if the client disconnects uncleanly (e.g. power failure, network drop, process kill).

- **`online` published in `_on_connect`** — after a successful (re)connect the plugin immediately publishes `online` (retained, QoS 1) to the availability topic, restoring entity availability in HA.

- **`offline` published in `__del__` before disconnect** — a clean disconnect suppresses the LWT, so an explicit `offline` message is published before `disconnect()` on graceful shutdown so HA marks entities unavailable immediately rather than waiting for the keepalive timeout.

- **`availability` block added to all discovery payloads** — every entity config now includes `{"availability": [{"topic": "openeo/<device_id>/availability"}]}` so HA knows which topic controls the entity's availability state.

## Testing

**Unclean disconnect (power failure / crash simulation)**
1. Start openeo; confirm all entities are `available` in HA.
2. Kill the process abruptly (`kill -9`).
3. Wait for the MQTT keepalive timeout to expire.
4. Confirm all openeo entities show as `unavailable` in HA.

**Clean shutdown**
1. Start openeo; confirm all entities are `available` in HA.
2. Stop openeo gracefully (Ctrl-C or service stop).
3. Confirm all openeo entities show as `unavailable` in HA immediately.

**Recovery**
1. Restart openeo after either of the above.
2. Confirm all entities return to `available` in HA within a few seconds of reconnect.